### PR TITLE
Drop libxkbcommon

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ Install dependencies:
 * meson \*
 * wayland
 * wayland-protocols \*
-* libxkbcommon
 * cairo
 * gdk-pixbuf2 \*\*
 * [scdoc](https://git.sr.ht/~sircmpwn/scdoc) (optional: man pages) \*

--- a/meson.build
+++ b/meson.build
@@ -28,7 +28,6 @@ endif
 
 wayland_client = dependency('wayland-client')
 wayland_protos = dependency('wayland-protocols', version: '>=1.14')
-xkbcommon      = dependency('xkbcommon')
 cairo          = dependency('cairo')
 gdk_pixbuf     = dependency('gdk-pixbuf-2.0', required: get_option('gdk-pixbuf'))
 
@@ -101,7 +100,6 @@ dependencies = [
 	cairo,
 	client_protos,
 	gdk_pixbuf,
-	xkbcommon,
 	wayland_client,
 ]
 


### PR DESCRIPTION
[Builds fine](https://github.com/swaywm/swaybg/files/3122092/swaybg-s20190425.log) without:
```
=>> Checking shared library dependencies
 0x00000001 NEEDED               Shared library: [libc.so.7]
 0x00000001 NEEDED               Shared library: [libcairo.so.2]
 0x00000001 NEEDED               Shared library: [libgdk_pixbuf-2.0.so.0]
 0x00000001 NEEDED               Shared library: [libgobject-2.0.so.0]
 0x00000001 NEEDED               Shared library: [libwayland-client.so.0]
```

