### PR TITLE
Changed link to the seperate project instead of sway main project

### DIFF
--- a/swaybg.1.scd
+++ b/swaybg.1.scd
@@ -41,4 +41,4 @@ these options.
 
 Maintained by Drew DeVault <sir@cmpwn.com>, who is assisted by other open
 source contributors. For more information about swaybg development, see
-https://github.com/swaywm/sway.
+https://github.com/swaywm/swaybg.


### PR DESCRIPTION
the man page should now send you to the swaybg github, not the sway one.