### PR TITLE
Reduce memory usage at rest

### DIFF
--- a/include/pool-buffer.h
+++ b/include/pool-buffer.h
@@ -9,14 +9,12 @@ struct pool_buffer {
 	struct wl_buffer *buffer;
 	cairo_surface_t *surface;
 	cairo_t *cairo;
-	uint32_t width, height;
 	void *data;
 	size_t size;
-	bool busy;
 };
 
-struct pool_buffer *get_next_buffer(struct wl_shm *shm,
-		struct pool_buffer pool[static 2], uint32_t width, uint32_t height);
+bool create_buffer(struct pool_buffer *buffer, struct wl_shm *shm,
+		int32_t width, int32_t height, uint32_t format);
 void destroy_buffer(struct pool_buffer *buffer);
 
 #endif


### PR DESCRIPTION
This PR partially addresses #14. See commit messages for details.

There is a new dependency on gio-unix-2.0, to provide the 20 necessary lines of code from [`g_unix_input_stream_new`](https://github.com/frida/glib/blob/master/gio/gunixinputstream.c). This can be removed (at +38/-12 diff cost) if the code switches to using GdkPixbufLoader directly.