### PR TITLE
Avoid setting dirty flag when nothing has changed

### DIFF
--- a/main.c
+++ b/main.c
@@ -195,9 +195,10 @@ static void layer_surface_configure(void *data,
 		struct zwlr_layer_surface_v1 *surface,
 		uint32_t serial, uint32_t width, uint32_t height) {
 	struct swaybg_output *output = data;
+	bool changed = width != output->width || height != output->height;
 	output->width = width;
 	output->height = height;
-	output->dirty = true;
+	output->dirty |= changed;
 	output->configure_serial = serial;
 	output->needs_ack = true;
 }
@@ -233,9 +234,10 @@ static void output_done(void *data, struct wl_output *output) {
 static void output_scale(void *data, struct wl_output *wl_output,
 		int32_t scale) {
 	struct swaybg_output *output = data;
+	bool changed = scale != output->scale;
 	output->scale = scale;
 	if (output->state->run_display && output->width > 0 && output->height > 0) {
-		output->dirty = true;
+		output->dirty |= changed;
 	}
 }
 


### PR DESCRIPTION
I observed significant CPU usage from swaybg (mostly in various pixman functions) while testing an unrelated wlr-layer-shell client. It turned out that that client was calling `zwlr_layer_surface_v1_set_size` at ~1Hz, which is not an excessive rate, and each of these calls resulted in the compositor (sway 1.6-bebb726b, but also reproduced with another wlroots-based compositor) sending swaybg a `zwlr_layer_surface_v1::configure` event at the same frequency. swaybg unconditionally treats such events as dirtying and as such it was wasting a lot of CPU.

This PR just changes swaybg to only set its dirty flag when an event gives width/height/scale a value different from the last one observed for it.

I believe this would also have mitigated issues such as #33 and #38.