### PR TITLE
Fix memory leak when using image tile mode

### DIFF
--- a/background-image.c
+++ b/background-image.c
@@ -108,6 +108,7 @@ void render_background_image(cairo_t *cairo, cairo_surface_t *image,
 		cairo_pattern_t *pattern = cairo_pattern_create_for_surface(image);
 		cairo_pattern_set_extend(pattern, CAIRO_EXTEND_REPEAT);
 		cairo_set_source(cairo, pattern);
+		cairo_pattern_destroy(pattern);
 		break;
 	}
 	case BACKGROUND_MODE_SOLID_COLOR:


### PR DESCRIPTION
This fixes a significant memory leak which occurs when using the `tile` image scaling mode; it was brought to my attention by https://github.com/swaywm/swaybg/issues/14#issuecomment-1059096139 .

To test this change, run a nested instance of Sway; inside it, run `swaybg -i image.jpg -m tile`; and then resize the nested Sway several times, and watch its memory usage.  Before this change, every time the frame was redrawn, a copy of the pixel data for image.jpg would be leaked; for large images, this can be a few hundred MB, every time.