### PR TITLE
man: fix background color input format

### DIFF
--- a/swaybg.1.scd
+++ b/swaybg.1.scd
@@ -16,7 +16,7 @@ these options.
 
 # OPTIONS
 
-*-c, --color* <rrggbb[aa]>
+*-c, --color* <#rrggbb>
 	Set the background color.
 
 *-h, --help*


### PR DESCRIPTION
With this change, the man page matches the format enforced by the code:
```
2022-07-02 10:11:12 - [swaybg/main.c:86] xyz is not a valid color for swaybg. Color should be specified as #rrggbb (no alpha).
```