### PR TITLE
Only submit XRGB buffers

### DIFF
--- a/main.c
+++ b/main.c
@@ -120,7 +120,7 @@ static struct wl_buffer *draw_buffer(const struct swaybg_output *output,
 
 	struct pool_buffer buffer;
 	if (!create_buffer(&buffer, output->state->shm,
-			buffer_width, buffer_height, WL_SHM_FORMAT_ARGB8888)) {
+			buffer_width, buffer_height, WL_SHM_FORMAT_XRGB8888)) {
 		return NULL;
 	}
 

--- a/pool-buffer.c
+++ b/pool-buffer.c
@@ -59,7 +59,7 @@ bool create_buffer(struct pool_buffer *buf, struct wl_shm *shm,
 	buf->size = size;
 	buf->data = data;
 	buf->surface = cairo_image_surface_create_for_data(data,
-			CAIRO_FORMAT_ARGB32, width, height, stride);
+			CAIRO_FORMAT_RGB24, width, height, stride);
 	buf->cairo = cairo_create(buf->surface);
 	return true;
 }


### PR DESCRIPTION
These two commits resolve https://github.com/swaywm/swaybg/issues/26, by _always_ submitting opaque buffers. This is done by painting the buffers submitted with a uniform color, before drawing the image on top. The default color is chosen to match Sway's default background color, so that most people invoking swaybg under Sway with a semi-transparent (or badly sized `fit` or `center` mode image) will see the same result as before.

I've been undecided about this change for a while, since there is an alternative which preserves the current behavior; to detect  when the output image _may_ be semi-transparent, as a function of the scaling mode, the image size, the presence of the `--color` flag, and whether the image has an alpha channel. However, I don't think allowing transparency in edge cases is a good behavior for a wallpaper program to have, and solving #26 while keeping the current behavior makes the buffer creation logic more complicated, making changes like submitting 10-bit buffers -- for which Cairo only supports the opaque [RGB30 format](https://www.cairographics.org/manual/cairo-Image-Surfaces.html#cairo-format-t) -- harder to implement.





