### PR TITLE
Optionally submit 10 bit buffers

### DIFF
--- a/include/cairo_util.h
+++ b/include/cairo_util.h
@@ -10,6 +10,8 @@
 
 void cairo_set_source_u32(cairo_t *cairo, uint32_t color);
 
+void cairo_rgb30_swap_rb(cairo_surface_t *surface);
+
 #if HAVE_GDK_PIXBUF
 
 cairo_surface_t* gdk_cairo_image_surface_create_from_pixbuf(

--- a/pool-buffer.c
+++ b/pool-buffer.c
@@ -36,6 +36,18 @@ static int anonymous_shm_open(void) {
 	return -1;
 }
 
+static uint32_t cairo_format_from_wayland_shm(uint32_t shm) {
+	switch (shm) {
+	case WL_SHM_FORMAT_XRGB8888:
+		return CAIRO_FORMAT_RGB24;
+	case WL_SHM_FORMAT_XBGR2101010:
+	case WL_SHM_FORMAT_XRGB2101010:
+		return CAIRO_FORMAT_RGB30;
+	default:
+		assert(0);
+	}
+}
+
 bool create_buffer(struct pool_buffer *buf, struct wl_shm *shm,
 		int32_t width, int32_t height, uint32_t format) {
 	uint32_t stride = width * 4;
@@ -56,10 +68,11 @@ bool create_buffer(struct pool_buffer *buf, struct wl_shm *shm,
 	wl_shm_pool_destroy(pool);
 	close(fd);
 
+	cairo_format_t cairo_fmt = cairo_format_from_wayland_shm(format);
 	buf->size = size;
 	buf->data = data;
 	buf->surface = cairo_image_surface_create_for_data(data,
-			CAIRO_FORMAT_RGB24, width, height, stride);
+			cairo_fmt, width, height, stride);
 	buf->cairo = cairo_create(buf->surface);
 	return true;
 }


### PR DESCRIPTION
This PR makes Swaybg submit 10-bit buffers when the background image it is given is a 16-bit deep PNG file.

 ~This PR builds on top of !53, and makes Swaybg submit 10-bit buffers when the background image it is given is a 16-bit deep PNG file. (#53 is necessary since Cairo does not have an equivalent to CAIRO_FORMAT_RGB30 with an alpha channel; without #53, this code would render transparent 8-bit PNGs with alpha and 16-bit PNGs without.)~

~Note: loading 16-bit PNG images gave incorrect results with Cairo 1.17.2 through 1.17.5. Since 16 bit PNG images are rare, and most distributions either use stable releases (latest 1.16.0), or development snapshots (latest 1.17.6), this bug is unlikely to affect anyone. Cairo versions before 1.17.2 reduce 16-bit PNG files to 8-bit on loading; swaybg will continue to submit 8-bit buffers for these.~ Edit: Cairo 1.18 has now been out for a while.