### PR TITLE
Use fractional-scale-v1 to estimate buffer sizes

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -30,7 +30,7 @@ endif
 rt = cc.find_library('rt')
 
 wayland_client = dependency('wayland-client')
-wayland_protos = dependency('wayland-protocols', version: '>=1.26')
+wayland_protos = dependency('wayland-protocols', version: '>=1.31')
 wayland_scanner = dependency('wayland-scanner', version: '>=1.14.91', native: true)
 cairo = dependency('cairo')
 gdk_pixbuf = dependency('gdk-pixbuf-2.0', required: get_option('gdk-pixbuf'))
@@ -74,6 +74,7 @@ client_protocols = [
 	wl_protocol_dir / 'stable/xdg-shell/xdg-shell.xml',
 	wl_protocol_dir / 'stable/viewporter/viewporter.xml',
 	wl_protocol_dir / 'staging/single-pixel-buffer/single-pixel-buffer-v1.xml',
+	wl_protocol_dir / 'staging/fractional-scale/fractional-scale-v1.xml',
 	'wlr-layer-shell-unstable-v1.xml',
 ]
 


### PR DESCRIPTION
This PR lets swaybg use [wp-fractional-scale-v1](https://wayland.app/protocols/fractional-scale-v1) with wp-viewporter to submit buffers that more closely match the real output pixel dimensions. The first commit refactors the code to decouple buffer creation from surface scale configuration further.


 **Note:** ~~This is marked as a draft, and introduces a temporary commit to deal with the probable bug in which, with current sway/wlroots, the first fractional-scale-v1 event arrives *after* the first configure event and is also missing after output scale changes.~~
<details>
<summary>For example: 
</summary>


```
[3700439.334]  -> wl_compositor@5.create_surface(new id wl_surface@3)
[3700439.340]  -> wl_compositor@5.create_region(new id wl_region@11)
[3700439.347]  -> wl_surface@3.set_input_region(wl_region@11)
[3700439.354]  -> wl_region@11.destroy()
[3700439.361]  -> wp_fractional_scale_manager_v1@9.get_fractional_scale(new id wp_fractional_scale_v1@12, wl_surface@3)
[3700439.369]  -> wp_viewporter@7.get_viewport(new id wp_viewport@13, wl_surface@3)
[3700439.377]  -> zwlr_layer_shell_v1@6.get_layer_surface(new id zwlr_layer_surface_v1@14, wl_surface@3, wl_output@10, 0, "wallpaper")
[3700439.386]  -> zwlr_layer_surface_v1@14.set_size(0, 0)
[3700439.394]  -> zwlr_layer_surface_v1@14.set_anchor(15)
[3700439.399]  -> zwlr_layer_surface_v1@14.set_exclusive_zone(-1)
[3700439.406]  -> wl_surface@3.commit()
[3700439.518] wl_display@1.delete_id(11)
[3700439.526] zwlr_layer_surface_v1@14.configure(87935, 2560, 1440)
[3700439.531] zwlr_layer_surface_v1@14.configure(87938, 2560, 1440)
[3700439.537]  -> zwlr_layer_surface_v1@14.ack_configure(87938)
[3700468.552]  -> wl_shm@4.create_pool(new id wl_shm_pool@11, fd 5, 14745600)
[3700468.567]  -> wl_shm_pool@11.create_buffer(new id wl_buffer@15, 0, 2560, 1440, 10240, 0)
[3700468.573]  -> wl_shm_pool@11.destroy()
[3700481.901]  -> wl_surface@3.attach(wl_buffer@15, 0, 0)
[3700481.916]  -> wl_surface@3.damage_buffer(0, 0, 2560, 1440)
[3700481.920]  -> wl_buffer@15.destroy()
[3700481.924]  -> wp_viewport@13.set_destination(2560, 1440)
[3700481.927]  -> wl_surface@3.commit()
[3700496.018] wl_display@1.delete_id(11)
[3700496.038] wl_display@1.delete_id(15)
[3700496.042] wp_fractional_scale_v1@12.preferred_scale(120)
[3700496.046] zwlr_layer_surface_v1@14.configure(87941, 2560, 1440)
[3700496.051]  -> zwlr_layer_surface_v1@14.ack_configure(87941)
```

</details>

Edit: diagram of how this PR applies the viewport in the worst case, for comparison with #57. Note: this assumes the compositor _exactly_ applies the scale it claims, and stretches e.g 5 horizontal logical pixels onto 7.5 physical pixels. Current sway does not do this, and this PR appears to work fine there.
<details>

![grids-ugly](https://user-images.githubusercontent.com/7674289/220794826-aa738729-5679-4e1c-9375-eb077de0e70c.png)
</details>
