### PR TITLE
main.c: fix build against gcc-14 (-Walloc-size)

### DIFF
--- a/main.c
+++ b/main.c
@@ -455,7 +455,7 @@ static void parse_command_line(int argc, char **argv,
 		"Background Modes:\n"
 		"  stretch, fit, fill, center, tile, or solid_color\n";
 
-	struct swaybg_output_config *config = calloc(sizeof(struct swaybg_output_config), 1);
+	struct swaybg_output_config *config = calloc(1, sizeof(struct swaybg_output_config));
 	config->output = strdup("*");
 	config->mode = BACKGROUND_MODE_INVALID;
 	wl_list_init(&config->link); // init for safe removal
@@ -489,7 +489,7 @@ static void parse_command_line(int argc, char **argv,
 				// Empty config or merged on top of an existing one
 				destroy_swaybg_output_config(config);
 			}
-			config = calloc(sizeof(struct swaybg_output_config), 1);
+			config = calloc(1, sizeof(struct swaybg_output_config));
 			config->output = strdup(optarg);
 			config->mode = BACKGROUND_MODE_INVALID;
 			wl_list_init(&config->link);  // init for safe removal


### PR DESCRIPTION
`gcc-14` added a new `-Walloc-size` warning that makes sure that size of an individual element matches size of a pointed type:

        https://gcc.gnu.org/PR71219

`swaybg` triggers it on `calloc()` calls where member size is used as `1` (instead of member count):

    ../main.c:492:32: error: allocation of insufficient size '1' for type 'struct swaybg_output_config' with size '48' [-Werror=alloc-size]
      492 |                         config = calloc(sizeof(struct swaybg_output_config), 1);
          |                                ^