### PR TITLE
Unify color validation and parsing functions

### DIFF
--- a/swaybg.1.scd
+++ b/swaybg.1.scd
@@ -16,7 +16,7 @@ these options.
 
 # OPTIONS
 
-*-c, --color* <#rrggbb>
+*-c, --color* <[#]rrggbb>
 	Set the background color.
 
 *-h, --help*


### PR DESCRIPTION
This change simplifies the color parsing logic, and makes it possible to submit colors in both '#rrggbb' and 'rrggbb' forms, as can be done for all the other sway* programs. See commit message for more details.