### PR TITLE
wayland-protocols min. version to 1.26

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -30,7 +30,7 @@ cc = meson.get_compiler('c')
 rt = cc.find_library('rt')
 
 wayland_client = dependency('wayland-client')
-wayland_protos = dependency('wayland-protocols', version: '>=1.14')
+wayland_protos = dependency('wayland-protocols', version: '>=1.26')
 wayland_scanner = dependency('wayland-scanner', version: '>=1.14.91', native: true)
 cairo = dependency('cairo')
 gdk_pixbuf = dependency('gdk-pixbuf-2.0', required: get_option('gdk-pixbuf'))


### PR DESCRIPTION
In Ubuntu 22.04, default wayland-protocols version is 1.25, `single-pixel-buffer` feature is missing there