### PR TITLE
Correct for image orientation when loading image

### DIFF
--- a/background-image.c
+++ b/background-image.c
@@ -31,8 +31,12 @@ cairo_surface_t *load_background_image(const char *path) {
 				err->message);
 		return NULL;
 	}
-	image = gdk_cairo_image_surface_create_from_pixbuf(pixbuf);
+	// Correct for embedded image orientation; typical images are not
+	// rotated and will be handled efficiently
+	GdkPixbuf *oriented = gdk_pixbuf_apply_embedded_orientation(pixbuf);
 	g_object_unref(pixbuf);
+	image = gdk_cairo_image_surface_create_from_pixbuf(oriented);
+	g_object_unref(oriented);
 #else
 	image = cairo_image_surface_create_from_png(path);
 #endif // HAVE_GDK_PIXBUF


### PR DESCRIPTION
This should resolve issue #65. I checked that it worked with the following set of images, corresponding to EXIF orientations 1 through 8.

![logo_1](https://github.com/swaywm/swaybg/assets/7674289/d8c422d3-99bc-45e1-8ce3-0b879c36dbb3)![logo_2](https://github.com/swaywm/swaybg/assets/7674289/fcb927e0-fd4c-42f7-a922-a7a63bfbe83a)![logo_3](https://github.com/swaywm/swaybg/assets/7674289/27b42e76-381a-4cb8-bb55-55f59ff964ab)![logo_4](https://github.com/swaywm/swaybg/assets/7674289/913bdda3-02bf-4730-bd2a-254aacb3bbbe)

![logo_5](https://github.com/swaywm/swaybg/assets/7674289/61c42f8b-67b7-4761-96d6-4280351eba17)![logo_6](https://github.com/swaywm/swaybg/assets/7674289/0eb0fd7e-098b-48a6-b8ae-d8b4fcf8cb89)![logo_7](https://github.com/swaywm/swaybg/assets/7674289/85085e78-8eb0-4657-9c8f-4df5f932a66e)![logo_8](https://github.com/swaywm/swaybg/assets/7674289/3f54579f-7d2e-4044-9049-f6a2da4f7824)
