### PR TITLE
Fix crash when new output added

### DIFF
--- a/main.c
+++ b/main.c
@@ -653,12 +653,14 @@ int main(int argc, char **argv) {
 						output->configure_serial);
 			}
 
-			uint32_t buffer_width, buffer_height;
-			get_buffer_size(output, &buffer_width, &buffer_height);
-			bool buffer_change = output->buffer_width != buffer_width ||
-				output->buffer_height != buffer_height;
-			if (output->dirty && output->config->image && buffer_change) {
-				output->config->image->load_required = true;
+			if (output->dirty) {
+				uint32_t buffer_width, buffer_height;
+				get_buffer_size(output, &buffer_width, &buffer_height);
+				bool buffer_change = output->buffer_width != buffer_width ||
+					output->buffer_height != buffer_height;
+				if (output->config->image && buffer_change) {
+					output->config->image->load_required = true;
+				}
 			}
 		}
 


### PR DESCRIPTION
> Calling get_buffer_size on a newly created swaybg_output, before a config is assigned to a swaybg_output, is unnecessary and yields a null pointer dereference.

To reproduce the crash: open a nested instance of `sway`, run `swaybg` , and call `swaymsg create_output`.
