### PR TITLE
Update compiled version string to include swaybg version when Git is used

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -40,8 +40,8 @@ scdoc = find_program('scdoc', required: get_option('man-pages'), native: true)
 
 version = '"@0@"'.format(meson.project_version())
 if git.found()
-	git_commit = run_command([git, 'rev-parse', '--short', 'HEAD'], check: false)
-	git_branch = run_command([git, 'rev-parse', '--abbrev-ref', 'HEAD'], check: false)
+	git_commit = run_command([git, '--git-dir=.git', 'rev-parse', '--short', 'HEAD'], check: false)
+	git_branch = run_command([git, '--git-dir=.git', 'rev-parse', '--abbrev-ref', 'HEAD'], check: false)
 	if git_commit.returncode() == 0 and git_branch.returncode() == 0
 		version = '"@0@-@1@ (" __DATE__ ", branch \'@2@\')"'.format(
 			meson.project_version(),

--- a/meson.build
+++ b/meson.build
@@ -40,10 +40,14 @@ scdoc = find_program('scdoc', required: get_option('man-pages'), native: true)
 
 version = '"@0@"'.format(meson.project_version())
 if git.found()
-	git_commit_hash = run_command([git, 'describe', '--always', '--tags'], check: false)
+	git_commit = run_command([git, 'rev-parse', '--short', 'HEAD'], check: false)
 	git_branch = run_command([git, 'rev-parse', '--abbrev-ref', 'HEAD'], check: false)
-	if git_commit_hash.returncode() == 0 and git_branch.returncode() == 0
-		version = '"@0@ (" __DATE__ ", branch \'@1@\')"'.format(git_commit_hash.stdout().strip(), git_branch.stdout().strip())
+	if git_commit.returncode() == 0 and git_branch.returncode() == 0
+		version = '"@0@-@1@ (" __DATE__ ", branch \'@2@\')"'.format(
+			meson.project_version(),
+			git_commit.stdout().strip(),
+			git_branch.stdout().strip(),
+		)
 	endif
 endif
 


### PR DESCRIPTION
### build: include swaybg version in version string when using git

Update the version population to always include the swaybg fixed version string in the final version.

This replicates the [logic used in sway](https://github.com/swaywm/sway/blob/9bb45a403758c8606fe9a7f0b5b5316bae1a12dd/meson.build#L163-L171).

### build: avoid git repository discovery when determining version

When attempting to use Git to populate commit/branch information in a version string, it is possible through repository discovery that it uses Git information not relevant to project. For example, if repository content is extract into an interim build location when using an embedded build framework (e.g. Buildroot), the project will not have its Git repository to refer to. When it cannot find its repository, it will look into its parent folders and may find the Git repository of another project and use its branch/commit information.

This commit provides an explicit path to the project's Git repository when consider commit/branch information. This will prevent any repository discovery from occurring.

See also: https://github.com/swaywm/sway/pull/8273