### PR TITLE
Use color management protocol and load images with glycin

### DIFF
--- a/.build.yml
+++ b/.build.yml
@@ -1,7 +1,7 @@
 image: alpine/edge
 packages:
   - cairo-dev
-  - gdk-pixbuf-dev
+  - glycin-loaders-dev
   - meson
   - scdoc
   - wayland-dev

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Install dependencies:
 * wayland
 * wayland-protocols \*
 * cairo
-* gdk-pixbuf2 (optional: image formats other than PNG)
+* glycin (optional: image formats other than PNG)
 * [scdoc](https://git.sr.ht/~sircmpwn/scdoc) (optional: man pages) \*
 * git (optional: version information) \*
 

--- a/background-image.c
+++ b/background-image.c
@@ -161,7 +161,7 @@ bool load_background_image(const char *path, struct background_image *image) {
 }
 #endif
 
-void render_background_image(cairo_t *cairo, cairo_surface_t *image,
+static void render_background_image(cairo_t *cairo, cairo_surface_t *image,
 		enum background_mode mode, int buffer_width, int buffer_height) {
 	double width = cairo_image_surface_get_width(image);
 	double height = cairo_image_surface_get_height(image);
@@ -227,4 +227,389 @@ void render_background_image(cairo_t *cairo, cairo_surface_t *image,
 	}
 	cairo_paint(cairo);
 	cairo_restore(cairo);
+}
+
+/* CIE XYZ with D65 white point */
+struct xyz_color {
+	double x;
+	double y;
+	double z;
+};
+
+struct primaries {
+	double gx, gy;
+	double bx, by;
+	double rx, ry;
+	double wx, wy;
+};
+
+/** Return the color primaries for the given CICP value, falling back to an
+ *  arbitrary value if unrecognized. */
+struct primaries get_primaries(uint32_t value) {
+	/* See H.273 specification, Table 2.
+	 *
+	 * Note: the white point values given in H.273 are rounded from the
+	 * standard CIE 2 degree observer coordinates */
+	switch (value) {
+	default:
+		swaybg_log(LOG_DEBUG, "Unexpected CICP primary value %u, colors may be wrong", value);
+		return (struct primaries) {
+			.gx = 0.300, .gy = 0.600,
+			.bx = 0.150, .by = 0.060,
+			.rx = 0.640, .ry = 0.330,
+			.wx = 0.3127, .wy = 0.3290,
+		};
+	case 1:
+		return (struct primaries) {
+			.gx = 0.300, .gy = 0.600,
+			.bx = 0.150, .by = 0.060,
+			.rx = 0.640, .ry = 0.330,
+			.wx = 0.3127, .wy = 0.3290,
+		};
+
+	case 5:
+		return (struct primaries) {
+			.gx = 0.29, .gy = 0.60,
+			.bx = 0.15, .by = 0.06,
+			.rx = 0.64, .ry = 0.33,
+			.wx = 0.3127, .wy = 0.3290,
+		};
+
+	case 6:
+	case 7:
+		return (struct primaries) {
+			.gx = 0.310, .gy = 0.595,
+			.bx = 0.155, .by = 0.070,
+			.rx = 0.630, .ry = 0.340,
+			.wx = 0.3127, .wy = 0.3290,
+		};
+
+	case 9:
+		return (struct primaries) {
+			.gx = 0.170, .gy = 0.797,
+			.bx = 0.131, .by = 0.046,
+			.rx = 0.708, .ry = 0.292,
+			.wx = 0.3127, .wy = 0.3290,
+		};
+
+	case 12:
+		return (struct primaries) {
+			.gx = 0.265, .gy = 0.690,
+			.bx = 0.150, .by = 0.060,
+			.rx = 0.680, .ry = 0.320,
+			.wx = 0.3127, .wy = 0.3290,
+		};
+
+	case 22:
+		return (struct primaries) {
+			.gx = 0.295, .gy = 0.605,
+			.bx = 0.155, .by = 0.077,
+			.rx = 0.630, .ry = 0.340,
+			.wx = 0.3127, .wy = 0.3290,
+		};
+	}
+}
+
+typedef double (*transfer_fn)(double);
+
+
+static double linear_tf(double l) {
+	return fmax(0.0, fmin(l, 1.0));
+}
+
+static double gamma22_tf(double l) {
+	return pow(fmax(0.0, fmin(l, 1.0)), 1.0 / 2.2);
+}
+
+static double gamma28_tf(double l) {
+	return pow(fmax(0.0, fmin(l, 1.0)), 1.0 / 2.8);
+}
+
+static double smpte240m_tf(double l) {
+	l = fmax(0.0, fmin(l, 1.0));
+	double alpha = 1.111572195921731;
+	double beta = 0.022821585529445028;
+	if (l <= beta) {
+		return 4.0 * l;
+	} else {
+		return alpha * pow(l, 0.45) - (alpha - 1.0);
+	}
+}
+
+static double log100_tf(double l) {
+	return fmax(0.0, fmin(1.0, 1.0 + log10(l) / 2.0));
+}
+
+static double log316_tf(double l) {
+	return fmax(0.0, fmin(1.0, 1.0 + log10(l) / 2.5));
+}
+
+static double srgb_tf(double l) {
+	l = fmax(0.0, fmin(l, 1.0));
+	/* `beta` is root of `(1-1/2.4) beta - beta^(1-1/2.4) + 1/(2.4 * 12.92)`,
+	 * `alpha` is `12.92 * 2.4 beta^(1 - 1/2.4)`
+	 *
+	 * Note: this TF is often stated with alpha rounded to to 1.055,
+	 * for which the matching `beta` would be 0.0031308 */
+	double beta = 0.003041282560127519;
+	double alpha = 1.0550107189475868;
+	if (l <= beta) {
+		return 12.92 * l;
+	} else {
+		return alpha * pow(l, 1.0 / 2.4) - (alpha - 1.0);
+	}
+}
+
+static double srgb_tf_inverse(double v) {
+	v = fmax(0.0, fmin(v, 1.0));
+	double alpha = 1.0550107189475868;
+	double beta = 0.003041282560127519;
+	if (v <= beta * 12.92) {
+		return v / 12.92;
+	} else {
+		return pow((v + (alpha - 1.0)) / alpha, 2.4);
+	}
+}
+
+static double rec709_tf(double l) {
+	l = fmax(0.0, fmin(l, 1.0));
+	double alpha = 1.099296826809443;
+	double beta = 0.018053968510807813;
+	if (l <= beta) {
+		return 4.5 * l;
+	} else {
+		return alpha * pow(l, 0.45) - (alpha - 1.0);
+	}
+}
+
+static double pq_tf(double l) {
+	double c1 = 107.0 / 128.0;
+	double c2 = 2413.0 / 128.0;
+	double c3 = 2392.0 / 128.0;
+	double m = 2523.0 / 32.0;
+	double n = 653.0 / 4096.0;
+	// ref max 10^4 cd/m^2; the Wayland color protocol has
+	// 203 cd/m^2 as the reference white
+	double l0 = l * 203.0 / 10000.0;
+	l0 = fmax(0.0, fmin(l0, 1.0));
+	return pow((c1 + c2 * pow(l0, n)) / (1.0 + c3 * pow(l0, n)), m);
+}
+
+static double hlg_tf(double l) {
+	l = fmax(0.0, fmin(l, 1.0));
+	if (l >= 1.0 / 12.0) {
+		double a = 0.17883277;
+		double b = 0.28466892;
+		double c = 0.55991073;
+		return a * log(12.0 * l - b) + c;
+	} else {
+		return sqrt(3 * l);
+	}
+}
+
+/** Return the inverse of the transfer function from "electrical" to optical
+ * values.
+ *
+ * (The H.273 transfer functions may be either the EOTF or inverse of EOTF;
+ * for historical reasons the two can differ.) */
+static transfer_fn get_tf(uint32_t value) {
+	switch (value) {
+	case 1:
+	case 6:
+	case 14:
+	case 15:
+		return rec709_tf;
+	case 4:
+		return gamma22_tf;
+	case 5:
+		return gamma28_tf;
+	case 7:
+		return smpte240m_tf;
+	case 8:
+		return linear_tf;
+	case 9:
+		return log100_tf;
+	case 10:
+		return log316_tf;
+	default:
+		swaybg_log(LOG_DEBUG, "Unexpected CICP transfer characteristic value %u, colors may be wrong", value);
+		return srgb_tf;
+	case 13:
+		return srgb_tf;
+	case 16:
+		return pq_tf;
+	case 18:
+		return hlg_tf;
+	}
+}
+
+/** Return the transfer function from "electrical" to optical values.
+ */
+static transfer_fn get_tf_inverse(uint32_t value) {
+	// Only sRGB is needed at the moment
+	assert(value == 13);
+	return srgb_tf_inverse;
+}
+
+/* bt709, "sRGB" transfer function, full range */
+static const struct cicp default_cicp = {
+	.primaries = 1,
+	.transfer = 13,
+	.matrix = 0,
+	.range = 1,
+};
+
+static void invert_3x3(const double in[3][3], double out[3][3]) {
+	double x00 = in[1][1] * in[2][2] - in[1][2] * in[2][1];
+	double x01 = -(in[1][0] * in[2][2] - in[1][2] * in[2][0]);
+	double x02 = in[1][0] * in[2][1] - in[1][1] * in[2][0];
+	double x10 = -(in[0][1] * in[2][2] - in[0][2] * in[2][1]);
+	double x11 = in[0][0] * in[2][2] - in[0][2] * in[2][0];
+	double x12 = -(in[0][0] * in[2][1] - in[0][1] * in[2][0]);
+	double x20 = in[0][1] * in[1][2] - in[0][2] * in[1][1];
+	double x21 = -(in[0][0] * in[1][2] - in[0][2] * in[1][0]);
+	double x22 = in[0][0] * in[1][1] - in[0][1] * in[1][0];
+
+	double det = in[0][0] * x00 + in[0][1] * x01 + in[0][2] * x02;
+	assert(det != 0);
+	out[0][0] = x00 / det;
+	out[1][0] = x01 / det;
+	out[2][0] = x02 / det;
+	out[0][1] = x10 / det;
+	out[1][1] = x11 / det;
+	out[2][1] = x12 / det;
+	out[0][2] = x20 / det;
+	out[1][2] = x21 / det;
+	out[2][2] = x22 / det;
+}
+
+static void swap(double *a, double *b) {
+	double tmp = *a;
+	*a = *b;
+	*b = tmp;
+}
+
+static void transpose_3x3(double mtx[3][3]) {
+	swap(&mtx[0][1], &mtx[1][0]);
+	swap(&mtx[0][2], &mtx[2][0]);
+	swap(&mtx[1][2], &mtx[2][1]);
+}
+
+static void mul_3x3(const double mtx[3][3], const double in[3], double out[3]) {
+	out[0] = in[0] * mtx[0][0] + in[1] * mtx[0][1] + in[2] * mtx[0][2];
+	out[1] = in[0] * mtx[1][0] + in[1] * mtx[1][1] + in[2] * mtx[1][2];
+	out[2] = in[0] * mtx[2][0] + in[1] * mtx[2][1] + in[2] * mtx[2][2];
+}
+
+struct xyz_color srgb_to_xyz(uint32_t rgbx) {
+	struct primaries p = get_primaries(1);
+	transfer_fn transfer_inv =  get_tf_inverse(13);
+	double er = (double)((rgbx >> 24) & 0xff) / 255.0;
+	double eg = (double)((rgbx >> 16) & 0xff) / 255.0;
+	double eb = (double)((rgbx >> 8) & 0xff) / 255.0;
+
+	double o[3] = {transfer_inv(er), transfer_inv(eg), transfer_inv(eb)};
+
+	double xyz_base[3][3] = {
+		{p.rx / p.ry, 1.0, (1.0 - (p.rx + p.ry)) / p.ry},
+		{p.gx / p.gy, 1.0, (1.0 - (p.gx + p.gy)) / p.gy},
+		{p.bx / p.by, 1.0, (1.0 - (p.bx + p.by)) / p.by},
+	};
+	transpose_3x3(xyz_base);
+
+	double xyz_base_inv[3][3];
+	invert_3x3(xyz_base, xyz_base_inv);
+
+	double xyz_white[3] = {p.wx / p.wy, 1.0, (1.0 - (p.wx + p.wy)) / p.wy};
+	double scale[3];
+	mul_3x3(xyz_base_inv, xyz_white, scale);
+	double rgb_to_xyz[3][3] = {
+		{xyz_base[0][0] * scale[0], xyz_base[0][1] * scale[1], xyz_base[0][2] * scale[2]},
+		{xyz_base[1][0] * scale[0], xyz_base[1][1] * scale[1], xyz_base[1][2] * scale[2]},
+		{xyz_base[2][0] * scale[0], xyz_base[2][1] * scale[1], xyz_base[2][2] * scale[2]},
+	};
+
+	double xyz_to_rgb[3][3];
+	invert_3x3(rgb_to_xyz, xyz_to_rgb);
+
+	double xyz[3];
+	mul_3x3(rgb_to_xyz, o, xyz);
+
+	return (struct xyz_color) {
+		.x = xyz[0],
+		.y = xyz[1],
+		.z = xyz[2],
+	};
+}
+
+/** Convert an XYZ color to an encoded RGB color using CICP.
+ *
+ * TODO: add support for white point adaptation to allow translating between
+ * different illuminants; the exact method chosen should ideally match what
+ * Wayland compositors do.
+ */
+uint32_t xyz_to_cicp(struct xyz_color c, const struct cicp *cicp) {
+	struct primaries p = get_primaries(cicp->primaries);
+	transfer_fn transfer = get_tf(cicp->transfer);
+	if (cicp->range != 1) {
+		swaybg_log(LOG_DEBUG, "Unexpected CICP range value %u, colors may be wrong", cicp->range);
+	}
+	if (cicp->matrix != 0) {
+		swaybg_log(LOG_DEBUG, "Unexpected CICP matrix coefficient value %u, colors may be wrong", cicp->matrix);
+	}
+
+
+	double xyz_base[3][3] = {
+		{p.rx / p.ry, 1.0, (1.0 - (p.rx + p.ry)) / p.ry},
+		{p.gx / p.gy, 1.0, (1.0 - (p.gx + p.gy)) / p.gy},
+		{p.bx / p.by, 1.0, (1.0 - (p.bx + p.by)) / p.by},
+	};
+	transpose_3x3(xyz_base);
+
+	double xyz_base_inv[3][3];
+	invert_3x3(xyz_base, xyz_base_inv);
+
+	double xyz_white[3] = {p.wx / p.wy, 1.0, (1.0 - (p.wx + p.wy)) / p.wy};
+	double scale[3];
+	mul_3x3(xyz_base_inv, xyz_white, scale);
+	double rgb_to_xyz[3][3] = {
+		{xyz_base[0][0] * scale[0], xyz_base[0][1] * scale[1], xyz_base[0][2] * scale[2]},
+		{xyz_base[1][0] * scale[0], xyz_base[1][1] * scale[1], xyz_base[1][2] * scale[2]},
+		{xyz_base[2][0] * scale[0], xyz_base[2][1] * scale[1], xyz_base[2][2] * scale[2]},
+	};
+	double xyz_to_rgb[3][3];
+	invert_3x3(rgb_to_xyz, xyz_to_rgb);
+
+	double xyz[3] = {c.x, c.y, c.z};
+	double rgb[3];
+	mul_3x3(xyz_to_rgb, xyz, rgb);
+
+	uint8_t er = round(transfer(rgb[0]) * 255.0);
+	uint8_t eg = round(transfer(rgb[1]) * 255.0);
+	uint8_t eb = round(transfer(rgb[2]) * 255.0);
+
+	return ((uint32_t)er << 24) | ((uint32_t)eg << 16) | ((uint32_t)eb << 8) | 0xff;
+}
+
+
+void render_background(cairo_t *cairo, const struct background_image *image,
+		enum background_mode mode, int buffer_width, int buffer_height,
+		uint32_t bg_color_srgb) {
+
+	// Map the background color from sRGB to the same colorspace as the image.
+	// Blending may not be particularly accurate, but accurate blending is
+	// complicated to implement efficiently, and the discrepancy may be hard
+	// to notice except for wallpapers heavily using alpha transparency.
+
+	uint32_t bg_color = xyz_to_cicp(srgb_to_xyz(bg_color_srgb),
+		image && image->has_cicp ? &image->cicp : &default_cicp);
+
+	cairo_set_source_u32(cairo, bg_color);
+	cairo_paint(cairo);
+
+	if (image && image->cairo_surface) {
+		render_background_image(cairo, image->cairo_surface,
+			mode, buffer_width, buffer_height);
+	}
+
 }

--- a/cairo.c
+++ b/cairo.c
@@ -1,9 +1,6 @@
 #include <stdint.h>
 #include <cairo.h>
 #include "cairo_util.h"
-#if HAVE_GDK_PIXBUF
-#include <gdk-pixbuf/gdk-pixbuf.h>
-#endif
 
 void cairo_set_source_u32(cairo_t *cairo, uint32_t color) {
 	cairo_set_source_rgba(cairo,
@@ -28,99 +25,3 @@ cairo_subpixel_order_t to_cairo_subpixel_order(enum wl_output_subpixel subpixel)
 	}
 	return CAIRO_SUBPIXEL_ORDER_DEFAULT;
 }
-
-#if HAVE_GDK_PIXBUF
-cairo_surface_t* gdk_cairo_image_surface_create_from_pixbuf(const GdkPixbuf *gdkbuf) {
-	int chan = gdk_pixbuf_get_n_channels(gdkbuf);
-	if (chan < 3) {
-		return NULL;
-	}
-
-	const guint8* gdkpix = gdk_pixbuf_read_pixels(gdkbuf);
-	if (!gdkpix) {
-		return NULL;
-	}
-	gint w = gdk_pixbuf_get_width(gdkbuf);
-	gint h = gdk_pixbuf_get_height(gdkbuf);
-	int stride = gdk_pixbuf_get_rowstride(gdkbuf);
-
-	cairo_format_t fmt = (chan == 3) ? CAIRO_FORMAT_RGB24 : CAIRO_FORMAT_ARGB32;
-	cairo_surface_t * cs = cairo_image_surface_create (fmt, w, h);
-	cairo_surface_flush (cs);
-	if ( !cs || cairo_surface_status(cs) != CAIRO_STATUS_SUCCESS) {
-		return NULL;
-	}
-
-	int cstride = cairo_image_surface_get_stride(cs);
-	unsigned char * cpix = cairo_image_surface_get_data(cs);
-
-	if (chan == 3) {
-		int i;
-		for (i = h; i; --i) {
-			const guint8 *gp = gdkpix;
-			unsigned char *cp = cpix;
-			const guint8* end = gp + 3*w;
-			while (gp < end) {
-#if G_BYTE_ORDER == G_LITTLE_ENDIAN
-				cp[0] = gp[2];
-				cp[1] = gp[1];
-				cp[2] = gp[0];
-#else
-				cp[1] = gp[0];
-				cp[2] = gp[1];
-				cp[3] = gp[2];
-#endif
-				gp += 3;
-				cp += 4;
-			}
-			gdkpix += stride;
-			cpix += cstride;
-		}
-	} else {
-		/* premul-color = alpha/255 * color/255 * 255 = (alpha*color)/255
-		 * (z/255) = z/256 * 256/255     = z/256 (1 + 1/255)
-		 *         = z/256 + (z/256)/255 = (z + z/255)/256
-		 *         # recurse once
-		 *         = (z + (z + z/255)/256)/256
-		 *         = (z + z/256 + z/256/255) / 256
-		 *         # only use 16bit uint operations, loose some precision,
-		 *         # result is floored.
-		 *       ->  (z + z>>8)>>8
-		 *         # add 0x80/255 = 0.5 to convert floor to round
-		 *       =>  (z+0x80 + (z+0x80)>>8 ) >> 8
-		 * ------
-		 * tested as equal to lround(z/255.0) for uint z in [0..0xfe02]
-		 */
-#define PREMUL_ALPHA(x,a,b,z) \
-		G_STMT_START { z = a * b + 0x80; x = (z + (z >> 8)) >> 8; } \
-		G_STMT_END
-		int i;
-		for (i = h; i; --i) {
-			const guint8 *gp = gdkpix;
-			unsigned char *cp = cpix;
-			const guint8* end = gp + 4*w;
-			guint z1, z2, z3;
-			while (gp < end) {
-#if G_BYTE_ORDER == G_LITTLE_ENDIAN
-				PREMUL_ALPHA(cp[0], gp[2], gp[3], z1);
-				PREMUL_ALPHA(cp[1], gp[1], gp[3], z2);
-				PREMUL_ALPHA(cp[2], gp[0], gp[3], z3);
-				cp[3] = gp[3];
-#else
-				PREMUL_ALPHA(cp[1], gp[0], gp[3], z1);
-				PREMUL_ALPHA(cp[2], gp[1], gp[3], z2);
-				PREMUL_ALPHA(cp[3], gp[2], gp[3], z3);
-				cp[0] = gp[3];
-#endif
-				gp += 4;
-				cp += 4;
-			}
-			gdkpix += stride;
-			cpix += cstride;
-		}
-#undef PREMUL_ALPHA
-	}
-	cairo_surface_mark_dirty(cs);
-	return cs;
-}
-#endif // HAVE_GDK_PIXBUF

--- a/include/background-image.h
+++ b/include/background-image.h
@@ -1,6 +1,8 @@
 #ifndef _SWAY_BACKGROUND_IMAGE_H
 #define _SWAY_BACKGROUND_IMAGE_H
+
 #include "cairo_util.h"
+#include <stdbool.h>
 
 enum background_mode {
 	BACKGROUND_MODE_STRETCH,
@@ -12,8 +14,23 @@ enum background_mode {
 	BACKGROUND_MODE_INVALID,
 };
 
+/** CICP (coding-independent code point) values */
+struct cicp {
+	uint8_t primaries;
+	uint8_t transfer;
+	uint8_t matrix;
+	uint8_t range;
+};
+
+struct background_image {
+	cairo_surface_t *cairo_surface;
+	struct cicp cicp;
+	bool has_cicp;
+};
+
 enum background_mode parse_background_mode(const char *mode);
-cairo_surface_t *load_background_image(const char *path);
+/** On success, this returns true and fills *image. */
+bool load_background_image(const char *path, struct background_image *image);
 void render_background_image(cairo_t *cairo, cairo_surface_t *image,
 		enum background_mode mode, int buffer_width, int buffer_height);
 

--- a/include/background-image.h
+++ b/include/background-image.h
@@ -31,7 +31,18 @@ struct background_image {
 enum background_mode parse_background_mode(const char *mode);
 /** On success, this returns true and fills *image. */
 bool load_background_image(const char *path, struct background_image *image);
-void render_background_image(cairo_t *cairo, cairo_surface_t *image,
-		enum background_mode mode, int buffer_width, int buffer_height);
+
+/** Render `image` (if provided) according to the given mode.
+ *
+ * This will produce a buffer in the color space indicated by the image's CICP,
+ * if present. `bg_color_srgb` is the sRGB background color and will be
+ * transformed to remain accurate if the output is rendered using the CICP.
+ *
+ * `buffer_width` and `buffer_height` are the target buffer dimensions
+ * (in physical pixels). Physical pixels are assumed square.
+ */
+void render_background(cairo_t *cairo, const struct background_image *image,
+		enum background_mode mode, int buffer_width, int buffer_height,
+		uint32_t bg_color_srgb);
 
 #endif

--- a/include/cairo_util.h
+++ b/include/cairo_util.h
@@ -4,21 +4,11 @@
 #include <stdint.h>
 #include <cairo.h>
 #include <wayland-client.h>
-#if HAVE_GDK_PIXBUF
-#include <gdk-pixbuf/gdk-pixbuf.h>
-#endif
 
 void cairo_set_source_u32(cairo_t *cairo, uint32_t color);
 cairo_subpixel_order_t to_cairo_subpixel_order(enum wl_output_subpixel subpixel);
 
 cairo_surface_t *cairo_image_surface_scale(cairo_surface_t *image,
 		int width, int height);
-
-#if HAVE_GDK_PIXBUF
-
-cairo_surface_t* gdk_cairo_image_surface_create_from_pixbuf(
-		const GdkPixbuf *gdkbuf);
-
-#endif // HAVE_GDK_PIXBUF
 
 #endif

--- a/main.c
+++ b/main.c
@@ -308,14 +308,8 @@ static struct wl_buffer *draw_buffer(const struct swaybg_output *output,
 		return NULL;
 	}
 
-	cairo_t *cairo = buffer.cairo;
-	cairo_set_source_u32(cairo, bg_color);
-	cairo_paint(cairo);
-
-	if (image && image->cairo_surface) {
-		render_background_image(cairo, image->cairo_surface,
-			output->config->mode, buffer_width, buffer_height);
-	}
+	render_background(buffer.cairo, image, output->config->mode,
+		buffer_width, buffer_height, bg_color);
 
 	// return wl_buffer for caller to use and destroy
 	struct wl_buffer *wl_buf = buffer.buffer;

--- a/main.c
+++ b/main.c
@@ -11,6 +11,7 @@
 #include "cairo_util.h"
 #include "log.h"
 #include "pool-buffer.h"
+#include "color-management-v1-client-protocol.h"
 #include "wlr-layer-shell-unstable-v1-client-protocol.h"
 #include "viewporter-client-protocol.h"
 #include "single-pixel-buffer-v1-client-protocol.h"
@@ -41,6 +42,96 @@ static bool parse_color(const char *color, uint32_t *result) {
 	return true;
 }
 
+static bool parse_rendering_intent(const char *str, enum wp_color_manager_v1_render_intent *intent) {
+	enum wp_color_manager_v1_render_intent val = WP_COLOR_MANAGER_V1_RENDER_INTENT_PERCEPTUAL;
+	if (strcmp(str, "perceptual") == 0) {
+		val = WP_COLOR_MANAGER_V1_RENDER_INTENT_PERCEPTUAL;
+	} else if (strcmp(str, "relative") == 0) {
+		val = WP_COLOR_MANAGER_V1_RENDER_INTENT_RELATIVE;
+	} else if (strcmp(str, "saturation") == 0) {
+		val = WP_COLOR_MANAGER_V1_RENDER_INTENT_SATURATION;
+	} else if (strcmp(str, "absolute") == 0) {
+		val = WP_COLOR_MANAGER_V1_RENDER_INTENT_ABSOLUTE;
+	} else if (strcmp(str, "relative_bpc") == 0) {
+		val = WP_COLOR_MANAGER_V1_RENDER_INTENT_RELATIVE_BPC;
+	} else {
+		return false;
+	}
+	*intent = val;
+	return true;
+}
+
+
+static const char *rendering_intent_names[] = {
+	"perceptual",
+	"relative",
+	"saturation",
+	"absolute",
+	"relative_bpc",
+};
+
+static const char *transfer_function_names[] = {
+	"unknown",
+	"bt1886",
+	"gamma22",
+	"gamma28",
+	"st240",
+	"ext_linear",
+	"log100",
+	"log316",
+	"xvycc",
+	"srgb",
+	"ext_srgb",
+	"st2084_pq",
+	"st428",
+	"hlg",
+	"compound2_4"
+};
+
+/** Map CICP primary code to the WP_COLOR_MANAGER_V1_PRIMARIES enum
+ * (or 0 if no match). */
+uint32_t cicp_to_wl_primaries(uint8_t primaries) {
+	switch (primaries) {
+	case 1:
+		return WP_COLOR_MANAGER_V1_PRIMARIES_SRGB;
+	case 2: // unspecified
+		return 0;
+	case 4:
+		return WP_COLOR_MANAGER_V1_PRIMARIES_PAL_M;
+	case 5:
+		return WP_COLOR_MANAGER_V1_PRIMARIES_PAL;
+	case 6:
+	case 7:
+		return WP_COLOR_MANAGER_V1_PRIMARIES_NTSC;
+	case 8:
+		return WP_COLOR_MANAGER_V1_PRIMARIES_GENERIC_FILM;
+	case 9:
+		return WP_COLOR_MANAGER_V1_PRIMARIES_BT2020;
+	case 10:
+		return WP_COLOR_MANAGER_V1_PRIMARIES_CIE1931_XYZ;
+	case 11:
+		return WP_COLOR_MANAGER_V1_PRIMARIES_DCI_P3;
+	case 12:
+		return WP_COLOR_MANAGER_V1_PRIMARIES_DISPLAY_P3;
+	default:
+		return 0;
+	}
+}
+
+static const char *primary_names[] = {
+	"unknown",
+	"srgb",
+	"pal_m",
+	"pam",
+	"ntsc",
+	"generic_film",
+	"bt2020",
+	"cie1931_xyz",
+	"dci_p3",
+	"display_p3",
+	"adobe_rgb",
+};
+
 struct swaybg_state {
 	struct wl_display *display;
 	struct wl_compositor *compositor;
@@ -49,10 +140,17 @@ struct swaybg_state {
 	struct wp_viewporter *viewporter;
 	struct wp_single_pixel_buffer_manager_v1 *single_pixel_buffer_manager;
 	struct wp_fractional_scale_manager_v1 *fract_scale_manager;
+	struct wp_color_manager_v1 *color_manager;
 	struct wl_list configs;  // struct swaybg_output_config::link
 	struct wl_list outputs;  // struct swaybg_output::link
 	struct wl_list images;   // struct swaybg_image::link
 	bool run_display;
+	/* Color management features and capabilities */
+	bool has_parametric;
+	bool supported_intents[sizeof(rendering_intent_names) / sizeof(rendering_intent_names[0])];
+	bool supported_named_primaries[sizeof(primary_names) / sizeof(primary_names[0])];
+	bool supported_named_tfs[sizeof(transfer_function_names) / sizeof(transfer_function_names[0])];
+	bool color_info_done;
 };
 
 struct swaybg_image {
@@ -66,6 +164,7 @@ struct swaybg_output_config {
 	const char *image_path;
 	struct swaybg_image *image;
 	enum background_mode mode;
+	enum wp_color_manager_v1_render_intent rendering_intent;
 	uint32_t color;
 	struct wl_list link;
 };
@@ -83,6 +182,7 @@ struct swaybg_output {
 	struct zwlr_layer_surface_v1 *layer_surface;
 	struct wp_viewport *viewport;
 	struct wp_fractional_scale_v1 *fract_scale;
+	struct wp_color_management_surface_v1 *color_surface;
 
 	uint32_t width, height;
 	int32_t scale;
@@ -96,9 +196,93 @@ struct swaybg_output {
 	struct wl_list link;
 };
 
+
+/** Map CICP transfer code to the WP_COLOR_MANAGER_V1_TRANSFER_FUNCTION enum
+ * (or 0 if no match). */
+uint32_t cicp_to_wl_tf(uint8_t transfer, const struct swaybg_state *state) {
+	switch (transfer) {
+	case 1:
+	case 6:
+	case 14:
+	case 15:
+		return WP_COLOR_MANAGER_V1_TRANSFER_FUNCTION_BT1886;
+	case 2: // unspecified
+		return 0;
+	case 4:
+		return WP_COLOR_MANAGER_V1_TRANSFER_FUNCTION_GAMMA22;
+	case 5:
+		return WP_COLOR_MANAGER_V1_TRANSFER_FUNCTION_GAMMA28;
+	case 7:
+		return WP_COLOR_MANAGER_V1_TRANSFER_FUNCTION_ST240;
+	case 8: // this is an extension of tf=8 and will work on all tf=8 images
+		return WP_COLOR_MANAGER_V1_TRANSFER_FUNCTION_EXT_LINEAR;
+	case 9:
+		return WP_COLOR_MANAGER_V1_TRANSFER_FUNCTION_LOG_100;
+	case 10:
+		return WP_COLOR_MANAGER_V1_TRANSFER_FUNCTION_LOG_316;
+	case 12:
+		return WP_COLOR_MANAGER_V1_TRANSFER_FUNCTION_XVYCC;
+	case 13: // swaybg only supports MatrixCoefficients = 0
+		if (wp_color_manager_v1_get_version(state->color_manager) <= 1) {
+			return WP_COLOR_MANAGER_V1_TRANSFER_FUNCTION_SRGB;
+		} else {
+			/* Some 'sRGB' images were created assuming Gamma 2.2-type decoding,
+			 * others assume the inverse of the encoding formula; most wallpaper
+			 * designers probably didn't think about it at all. Whatever is
+			 * chosen will be wrong a fraction of the time. */
+			if (state->supported_named_tfs[WP_COLOR_MANAGER_V1_TRANSFER_FUNCTION_COMPOUND_POWER_2_4]) {
+				return WP_COLOR_MANAGER_V1_TRANSFER_FUNCTION_COMPOUND_POWER_2_4;
+			} else {
+				return WP_COLOR_MANAGER_V1_TRANSFER_FUNCTION_GAMMA22;
+			}
+		}
+	case 16: // with reference white specified
+		return WP_COLOR_MANAGER_V1_TRANSFER_FUNCTION_ST2084_PQ;
+	case 17:
+		return WP_COLOR_MANAGER_V1_TRANSFER_FUNCTION_ST428;
+	case 18: // with reference white specified
+		return WP_COLOR_MANAGER_V1_TRANSFER_FUNCTION_HLG;
+	default:
+		return 0;
+	}
+}
+
+
+enum image_desc_state {
+	IMAGE_DESC_WAITING,
+	IMAGE_DESC_READY,
+	IMAGE_DESC_FAILED,
+};
+
+static void image_desc_failed(void *data,
+		struct wp_image_description_v1 *wp_image_description_v1,
+		uint32_t cause, const char *msg) {
+	enum image_desc_state *state = data;
+	*state = IMAGE_DESC_FAILED;
+}
+
+static void image_desc_ready(void *data,
+		struct wp_image_description_v1 *wp_image_description_v1, uint32_t identity) {
+	enum image_desc_state *state = data;
+	*state = IMAGE_DESC_READY;
+}
+
+static void image_desc_ready2(void *data,
+		struct wp_image_description_v1 *wp_image_description_v1,
+		uint32_t identity_hi, uint32_t identity_lo) {
+	enum image_desc_state *state = data;
+	*state = IMAGE_DESC_READY;
+}
+
+static const struct wp_image_description_v1_listener image_desc_listener = {
+	.failed = image_desc_failed,
+	.ready = image_desc_ready,
+	.ready2 = image_desc_ready2,
+};
+
 // Create a wl_buffer with the specified dimensions and content
 static struct wl_buffer *draw_buffer(const struct swaybg_output *output,
-		cairo_surface_t *surface, uint32_t buffer_width, uint32_t buffer_height) {
+		const struct background_image *image, uint32_t buffer_width, uint32_t buffer_height) {
 	uint32_t bg_color = output->config->color ? output->config->color : 0x000000ff;
 
 	if (buffer_width == 1 && buffer_height == 1 &&
@@ -128,8 +312,8 @@ static struct wl_buffer *draw_buffer(const struct swaybg_output *output,
 	cairo_set_source_u32(cairo, bg_color);
 	cairo_paint(cairo);
 
-	if (surface) {
-		render_background_image(cairo, surface,
+	if (image && image->cairo_surface) {
+		render_background_image(cairo, image->cairo_surface,
 			output->config->mode, buffer_width, buffer_height);
 	}
 
@@ -161,7 +345,67 @@ static void get_buffer_size(const struct swaybg_output *output,
 	}
 }
 
-static void render_frame(struct swaybg_output *output, cairo_surface_t *surface) {
+static bool is_color_desc_supported(const struct cicp *cicp,
+		const struct swaybg_state *state) {
+	bool supported = true;
+	uint32_t tf = cicp_to_wl_tf(cicp->transfer, state);
+	uint32_t primaries = cicp_to_wl_primaries(cicp->primaries);
+
+	if (cicp->matrix != 0) {
+		swaybg_log(LOG_ERROR, "Failed to create image description, CICP matrix = %d != 0=RGB", cicp->matrix);
+		supported = false;
+	}
+	if (cicp->range != 1) {
+		swaybg_log(LOG_ERROR, "Failed to create image description, CICP range = %d != 1=full", cicp->range);
+		supported = false;
+	}
+
+	if (tf >= sizeof(state->supported_named_tfs) / sizeof(state->supported_named_tfs[0])) {
+		swaybg_log(LOG_ERROR,
+			"Failed to create image description, named transfer function wl=%d, cicp=%d unknown",
+			tf, cicp->transfer);
+		supported = false;
+	} else if (!state->supported_named_tfs[tf]) {
+		swaybg_log(LOG_ERROR,
+			"Failed to create image description, named transfer function wl=%d=%s, cicp=%d not supported",
+			tf, transfer_function_names[tf], cicp->transfer);
+		supported = false;
+	}
+
+	if (primaries >= sizeof(state->supported_named_primaries) / sizeof(state->supported_named_primaries[0])) {
+		swaybg_log(LOG_ERROR,
+			"Failed to create image description, named primaries wl=%d, cicp=%d unknown",
+			primaries, cicp->primaries);
+		supported = false;
+	} else if (!state->supported_named_primaries[primaries]) {
+		swaybg_log(LOG_ERROR,
+			"Failed to create image description, named primaries wl=%d=%s, cicp=%d not supported",
+			primaries, primary_names[tf], cicp->primaries);
+		supported = false;
+	}
+
+	return supported;
+}
+
+static bool is_intent_supported(enum wp_color_manager_v1_render_intent intent,
+		const struct swaybg_state *state) {
+	if (intent >= sizeof(state->supported_intents) / sizeof(state->supported_intents[0])) {
+		swaybg_log(LOG_ERROR,
+			"Failed to create image description, rendering intent %d unknown",
+			intent);
+		return false;
+	} else if (!state->supported_intents[intent]) {
+		swaybg_log(LOG_ERROR,
+			"Failed to create image description, intent %d=%s not supported",
+			intent, rendering_intent_names[intent]);
+		return false;
+	} else {
+		return true;
+	}
+}
+
+
+static void render_frame(struct swaybg_output *output, const struct background_image *image) {
 	uint32_t buffer_width, buffer_height;
 	get_buffer_size(output, &buffer_width, &buffer_height);
 
@@ -169,8 +413,8 @@ static void render_frame(struct swaybg_output *output, cairo_surface_t *surface)
 	struct wl_buffer *buf = NULL;
 	if (buffer_width != output->buffer_width ||
 			buffer_height != output->buffer_height) {
-		buf = draw_buffer(output, surface,
-			buffer_width, buffer_height);
+
+		buf = draw_buffer(output, image, buffer_width, buffer_height);
 		if (!buf) {
 			return;
 		}
@@ -188,6 +432,50 @@ static void render_frame(struct swaybg_output *output, cairo_surface_t *surface)
 	} else {
 		wl_surface_set_buffer_scale(output->surface, output->scale);
 	}
+
+	if (image && image->has_cicp && output->color_surface) {
+		uint32_t intent = output->config->rendering_intent;
+		uint32_t tf = cicp_to_wl_tf(image->cicp.transfer, output->state);
+		uint32_t primaries = cicp_to_wl_primaries(image->cicp.primaries);
+
+		bool cicp_supported = is_color_desc_supported(&image->cicp, output->state);
+		bool intent_supported = is_intent_supported(output->config->rendering_intent, output->state);
+
+		if (cicp_supported && intent_supported) {
+			struct wp_image_description_creator_params_v1 *params =
+			wp_color_manager_v1_create_parametric_creator(output->state->color_manager);
+			wp_image_description_creator_params_v1_set_primaries_named(params, primaries);
+			wp_image_description_creator_params_v1_set_tf_named(params, tf);
+
+			struct wp_image_description_v1 *desc =
+				wp_image_description_creator_params_v1_create(params);
+			enum image_desc_state state = IMAGE_DESC_WAITING;
+			wp_image_description_v1_add_listener(desc, &image_desc_listener, &state);
+
+			/* Block until image description is ready. This is of course slow;
+			 * image descriptions should instead be cached and asynchronously constructed. */
+			struct wl_event_queue *init_queue = wl_proxy_get_queue((struct wl_proxy *)desc);
+			struct wl_event_queue *queue = wl_display_create_queue_with_name(output->state->display, "image desc");
+			wl_proxy_set_queue((struct wl_proxy *)desc, queue);
+			while (state == IMAGE_DESC_WAITING) {
+				if (wl_display_dispatch_queue(output->state->display, queue) < 0) {
+					/* compositor disconnection, silently exit */
+					break;
+				}
+			}
+			wl_proxy_set_queue((struct wl_proxy *)desc, init_queue);
+			wl_event_queue_destroy(queue);
+
+			if (state == IMAGE_DESC_READY) {
+				wp_color_management_surface_v1_set_image_description(output->color_surface, desc, intent);
+			} else if (state == IMAGE_DESC_FAILED) {
+				swaybg_log(LOG_ERROR, "Failed to create image description, compositor sent ::failed() event");
+			}
+
+			wp_image_description_v1_destroy(desc);
+		}
+	}
+
 	wl_surface_commit(output->surface);
 	if (buf) {
 		wl_buffer_destroy(buf);
@@ -227,6 +515,9 @@ static void destroy_swaybg_output(struct swaybg_output *output) {
 	}
 	if (output->fract_scale != NULL) {
 		wp_fractional_scale_v1_destroy(output->fract_scale);
+	}
+	if (output->color_surface != NULL) {
+		wp_color_management_surface_v1_destroy(output->color_surface);
 	}
 	wl_output_destroy(output->wl_output);
 	free(output->name);
@@ -303,6 +594,11 @@ static void create_layer_surface(struct swaybg_output *output) {
 				output->state->fract_scale_manager)) {
 		output->viewport =  wp_viewporter_get_viewport(
 			output->state->viewporter, output->surface);
+	}
+
+	if (output->state->color_manager) {
+		output->color_surface = wp_color_manager_v1_get_surface(
+			output->state->color_manager, output->surface);
 	}
 
 	output->layer_surface = zwlr_layer_shell_v1_get_layer_surface(
@@ -398,6 +694,53 @@ static const struct wl_output_listener output_listener = {
 	.description = output_description,
 };
 
+
+static void color_supported_intent(void *data,
+		struct wp_color_manager_v1 *wp_color_manager_v1, uint32_t render_intent) {
+	struct swaybg_state *state = data;
+	if (render_intent < sizeof(state->supported_intents) / sizeof(state->supported_intents[0])) {
+		state->supported_intents[render_intent] = true;
+	}
+}
+
+static void color_supported_feature(void *data,
+		struct wp_color_manager_v1 *wp_color_manager_v1, uint32_t feature) {
+	struct swaybg_state *state = data;
+	if (feature == WP_COLOR_MANAGER_V1_FEATURE_PARAMETRIC) {
+		state->has_parametric = true;
+	}
+}
+
+static void color_supported_tf_named(void *data,
+		struct wp_color_manager_v1 *wp_color_manager_v1, uint32_t tf) {
+	struct swaybg_state *state = data;
+	if (tf < sizeof(state->supported_named_tfs) / sizeof(state->supported_named_tfs[0])) {
+		state->supported_named_tfs[tf] = true;
+	}
+}
+
+static void color_supported_primaries_named(void *data,
+		struct wp_color_manager_v1 *wp_color_manager_v1, uint32_t primaries) {
+	struct swaybg_state *state = data;
+	if (primaries < sizeof(state->supported_named_primaries) / sizeof(state->supported_named_primaries[0])) {
+		state->supported_named_primaries[primaries] = true;
+	}
+}
+
+static void color_done(void *data,
+		struct wp_color_manager_v1 *wp_color_manager_v1) {
+	struct swaybg_state *state = data;
+	state->color_info_done = true;
+}
+
+static const struct wp_color_manager_v1_listener color_manager_listener = {
+	.supported_intent = color_supported_intent,
+	.supported_feature = color_supported_feature,
+	.supported_tf_named = color_supported_tf_named,
+	.supported_primaries_named = color_supported_primaries_named,
+	.done = color_done,
+};
+
 static void handle_global(void *data, struct wl_registry *registry,
 		uint32_t name, const char *interface, uint32_t version) {
 	struct swaybg_state *state = data;
@@ -428,6 +771,11 @@ static void handle_global(void *data, struct wl_registry *registry,
 	} else if (strcmp(interface, wp_fractional_scale_manager_v1_interface.name) == 0) {
 		state->fract_scale_manager = wl_registry_bind(registry, name,
 			&wp_fractional_scale_manager_v1_interface, 1);
+	} else if (strcmp(interface, wp_color_manager_v1_interface.name) == 0) {
+		state->color_manager = wl_registry_bind(registry, name,
+			&wp_color_manager_v1_interface, version >= 2 ? 2 : version);
+		wp_color_manager_v1_add_listener(state->color_manager,
+			&color_manager_listener, state);
 	}
 }
 
@@ -479,6 +827,7 @@ static void parse_command_line(int argc, char **argv,
 		{"color", required_argument, NULL, 'c'},
 		{"help", no_argument, NULL, 'h'},
 		{"image", required_argument, NULL, 'i'},
+		{"render", required_argument, NULL, 'r'},
 		{"mode", required_argument, NULL, 'm'},
 		{"output", required_argument, NULL, 'o'},
 		{"version", no_argument, NULL, 'v'},
@@ -492,11 +841,14 @@ static void parse_command_line(int argc, char **argv,
 		"  -h, --help             Show help message and quit.\n"
 		"  -i, --image <path>     Set the image to display.\n"
 		"  -m, --mode <mode>      Set the mode to use for the image.\n"
+		"  -r, --render <intent>  Set the rendering intent to use if the image is color managed.\n"
 		"  -o, --output <name>    Set the output to operate on or * for all.\n"
 		"  -v, --version          Show the version number and quit.\n"
 		"\n"
 		"Background Modes:\n"
-		"  stretch, fit, fill, center, tile, or solid_color\n";
+		"  stretch, fit, fill, center, tile, or solid_color\n"
+		"Rendering intents (default=perceptual):\n"
+		"  perceptual, relative, saturation, absolute, relative_bpc\n";
 
 	struct swaybg_output_config *config = calloc(1, sizeof(struct swaybg_output_config));
 	config->output = strdup("*");
@@ -506,7 +858,7 @@ static void parse_command_line(int argc, char **argv,
 	int c;
 	while (1) {
 		int option_index = 0;
-		c = getopt_long(argc, argv, "c:hi:m:o:v", long_options, &option_index);
+		c = getopt_long(argc, argv, "c:hi:m:o:r:v", long_options, &option_index);
 		if (c == -1) {
 			break;
 		}
@@ -535,7 +887,13 @@ static void parse_command_line(int argc, char **argv,
 			config = calloc(1, sizeof(struct swaybg_output_config));
 			config->output = strdup(optarg);
 			config->mode = BACKGROUND_MODE_INVALID;
+			config->rendering_intent = WP_COLOR_MANAGER_V1_RENDER_INTENT_PERCEPTUAL;
 			wl_list_init(&config->link);  // init for safe removal
+			break;
+		case 'r':  // render
+			if (!parse_rendering_intent(optarg, &config->rendering_intent)) {
+				swaybg_log(LOG_ERROR, "Invalid rendering intent: %s", optarg);
+			}
 			break;
 		case 'v':  // version
 			fprintf(stdout, "swaybg version " SWAYBG_VERSION "\n");
@@ -632,6 +990,16 @@ int main(int argc, char **argv) {
 	}
 
 	state.run_display = true;
+
+	/* Before processing any images, wait to see what color management
+	 * supports, as this can affect what error messages are produced */
+	while (state.color_manager && !state.color_info_done && state.run_display) {
+		if (wl_display_dispatch(state.display) == -1) {
+			state.run_display = false;
+			break;
+		}
+	}
+
 	while (wl_display_dispatch(state.display) != -1 && state.run_display) {
 		// Send acks, and determine which images need to be loaded
 		struct swaybg_output *output;
@@ -660,8 +1028,8 @@ int main(int argc, char **argv) {
 				continue;
 			}
 
-			cairo_surface_t *surface = load_background_image(image->path);
-			if (!surface) {
+			struct background_image bg = {0};
+			if (!load_background_image(image->path, &bg)) {
 				swaybg_log(LOG_ERROR, "Failed to load image: %s", image->path);
 				continue;
 			}
@@ -669,12 +1037,12 @@ int main(int argc, char **argv) {
 			wl_list_for_each(output, &state.outputs, link) {
 				if (output->dirty && output->config->image == image) {
 					output->dirty = false;
-					render_frame(output, surface);
+					render_frame(output, &bg);
 				}
 			}
 
 			image->load_required = false;
-			cairo_surface_destroy(surface);
+			cairo_surface_destroy(bg.cairo_surface);
 		}
 
 		// Redraw outputs without associated image
@@ -699,6 +1067,10 @@ int main(int argc, char **argv) {
 	struct swaybg_image *tmp_image;
 	wl_list_for_each_safe(image, tmp_image, &state.images, link) {
 		destroy_swaybg_image(image);
+	}
+
+	if (state.color_manager) {
+		wp_color_manager_v1_destroy(state.color_manager);
 	}
 
 	return 0;

--- a/meson.build
+++ b/meson.build
@@ -33,7 +33,7 @@ wayland_client = dependency('wayland-client')
 wayland_protos = dependency('wayland-protocols', version: '>=1.31')
 wayland_scanner = dependency('wayland-scanner', version: '>=1.14.91', native: true)
 cairo = dependency('cairo')
-gdk_pixbuf = dependency('gdk-pixbuf-2.0', required: get_option('gdk-pixbuf'))
+glycin = dependency('glycin-2', required: get_option('glycin'), version: '>=2.0.0')
 
 git = find_program('git', required: false, native: true)
 scdoc = find_program('scdoc', required: get_option('man-pages'), native: true)
@@ -53,7 +53,7 @@ endif
 
 add_project_arguments([
 	'-DSWAYBG_VERSION=@0@'.format(version),
-	'-DHAVE_GDK_PIXBUF=@0@'.format(gdk_pixbuf.found().to_int()),
+	'-DHAVE_GLYCIN=@0@'.format(glycin.found().to_int()),
 ], language: 'c')
 
 wl_protocol_dir = wayland_protos.get_variable('pkgdatadir')
@@ -101,7 +101,7 @@ executable(
 	dependencies: [
 		cairo,
 		rt,
-		gdk_pixbuf,
+		glycin,
 		wayland_client,
 	],
 	install: true

--- a/meson.build
+++ b/meson.build
@@ -77,6 +77,7 @@ protos_src = []
 client_protocols = [
 	wl_protocol_dir / 'stable/xdg-shell/xdg-shell.xml',
 	wl_protocol_dir / 'stable/viewporter/viewporter.xml',
+	wl_protocol_dir / 'staging/color-management/color-management-v1.xml',
 	wl_protocol_dir / 'staging/single-pixel-buffer/single-pixel-buffer-v1.xml',
 	wl_protocol_dir / 'staging/fractional-scale/fractional-scale-v1.xml',
 	'wlr-layer-shell-unstable-v1.xml',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,2 +1,2 @@
-option('gdk-pixbuf', type: 'feature', value: 'auto', description: 'Enable support for more image formats')
+option('glycin', type: 'feature', value: 'auto', description: 'Enable support for more image formats')
 option('man-pages', type: 'feature', value: 'auto', description: 'Generate and install man pages')

--- a/swaybg.1.scd
+++ b/swaybg.1.scd
@@ -17,7 +17,11 @@ these options.
 # OPTIONS
 
 *-c, --color* <[#]rrggbb>
-	Set the background color.
+	Set the background color. (The specific color model is typically sRGB or
+	however the compositor interprets color values by default, but if a background
+	image is set for which swaybg can use color management under the given Wayland
+	compositor, then the background color interpretation is unspecified and may
+	be changed in the future.)
 
 *-h, --help*
 	Show help message and quit.
@@ -26,13 +30,21 @@ these options.
 	Set the background image.
 
 *-m, --mode* <mode>
-	Scaling mode for images: _stretch_, _fill_, _fit_, _center_, or _tile_.
-	Default is _stretch_. Use the additional mode _solid\_color_ to display
-	only the background color, even if a background image is specified.
+	Scaling mode for images: _stretch_, _fill_, _fit_, _center_, or _tile_. Use
+	the additional mode _solid\_color_ to display only the background color,
+	even if a background image is specified.
 
 *-o, --output* <name>
 	Select an output to configure. Subsequent appearance options will only
 	apply to this output. The special value _\*_ selects all outputs.
+
+*-r, --render* <intent>
+	Rendering intents for images: _perceptual_, _relative_, _saturation_,
+	_absolute_, _relative_bpc_. The default is _perceptual_. These are only
+	applied if the compositor supports color management, an image is loaded
+	whose color properties are specified by a CICP chunk, and the compositor
+	supports the given rendering intent, the image color primaries, and the
+	image transfer function. CICP chunks are supported for PNG, JXL, and AVIF.
 
 *-v, --version*
 	Show the version number and quit.


### PR DESCRIPTION
This is an alternative to https://github.com/swaywm/swaybg/pull/86, which switches the image loader to glycin (a library now used as the main backend for gdk-pixbuf) instead of directly using libpng. On the color management side:

* Adds a -r/--render command line argument to specify the rendering intent for the image.
* Only attempts color management for images with a CICP chunk; PNG, AVIF, JXL image types support this
* Does not handle any other color management methods (e.g.: PNG has mDCV, cLLI, sRGB, gAMA, cHRM)
* Does not do color model aware blending (which would probably take another few hundred lines of code, or more, to handle all cases)
* Does not support high bit depths
* Does a blocking roundtrip whenever it commits a color managed surface. (Avoiding the roundtrip is possible but complicated: https://github.com/mstoeckl/swaybg/commit/46ce95b9aa26142efa96c7e1b3cd345f96dd49de.)

The change from gdk-pixbuf to glycin:
* Loses support for some rare image formats that gdk-pixbuf supported but glycin does not. Performance could also be worse in some cases due to sandboxing and new image handling code
* Should make loading high bit depth images of whatever type slightly easier in the future
* May cause unexpected issues
* Is already happening inside gdk-pixbuf, see https://gitlab.gnome.org/GNOME/gdk-pixbuf/-/issues/258. In theory, with this change swaybg should not be exposed to any more image format handling bugs than it would be without this PR. That being said, distributions may vary in how fast they start using glycin-based loaders in gdk-pixbuf, and gdk-pixbuf is not yet just a wrapper over glycin.
* May prevent building on FreeBSD, until the following is addressed: https://gitlab.gnome.org/GNOME/glycin/-/issues/106 (Edit: next major release should support it.)
* May make it harder to run newer version of swaybg on computers with more stable distributions; glycin is still a relatively new library and only version 2.0 supports image pixel format conversion. At minimum, I'd recommend not merging this before the start of 2026.