### PR TITLE
Use bright black rather than black for LOG_DEBUG

### DIFF
--- a/log.c
+++ b/log.c
@@ -13,7 +13,7 @@ static const char *verbosity_colors[] = {
 	[LOG_SILENT] = "",
 	[LOG_ERROR ] = "\x1B[1;31m",
 	[LOG_INFO  ] = "\x1B[1;34m",
-	[LOG_DEBUG ] = "\x1B[1;30m",
+	[LOG_DEBUG ] = "\x1B[1;90m",
 };
 
 void swaybg_log_init(enum log_importance verbosity) {


### PR DESCRIPTION
This makes swaybg's log colors consistent with swayidle (changed by https://github.com/swaywm/swayidle/pull/200) and sway (changed a few years ago by https://github.com/swaywm/sway/pull/5375). `swaylock` also should probably be updated to match.
