### PR TITLE
Added new "span" mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,6 @@ Run these commands:
     meson build/
     ninja -C build/
     sudo ninja -C build/ install
+
+## License
+swaybg is licensed under the MIT license. See [LICENSE](LICENSE) for details

--- a/include/background-image.h
+++ b/include/background-image.h
@@ -5,6 +5,7 @@
 enum background_mode {
 	BACKGROUND_MODE_STRETCH,
 	BACKGROUND_MODE_FILL,
+	BACKGROUND_MODE_SPAN,
 	BACKGROUND_MODE_FIT,
 	BACKGROUND_MODE_CENTER,
 	BACKGROUND_MODE_TILE,
@@ -15,6 +16,10 @@ enum background_mode {
 enum background_mode parse_background_mode(const char *mode);
 cairo_surface_t *load_background_image(const char *path);
 void render_background_image(cairo_t *cairo, cairo_surface_t *image,
-		enum background_mode mode, int buffer_width, int buffer_height);
+		enum background_mode mode, int buffer_width, int buffer_height,
+		int screen_pos_x_mm, int screen_pos_y_mm, 
+		int width_mm, int height_mm,
+		int total_width_mm, int total_height_mm,
+		int min_width_mm, int min_height_mm);
 
 #endif

--- a/meson.build
+++ b/meson.build
@@ -79,6 +79,7 @@ client_protocols = [
 	wl_protocol_dir / 'stable/viewporter/viewporter.xml',
 	wl_protocol_dir / 'staging/single-pixel-buffer/single-pixel-buffer-v1.xml',
 	wl_protocol_dir / 'staging/fractional-scale/fractional-scale-v1.xml',
+	wl_protocol_dir / 'unstable/xdg-output/xdg-output-unstable-v1.xml',
 	'wlr-layer-shell-unstable-v1.xml',
 ]
 

--- a/swaybg.1.scd
+++ b/swaybg.1.scd
@@ -26,9 +26,16 @@ these options.
 	Set the background image.
 
 *-m, --mode* <mode>
-	Scaling mode for images: _stretch_, _fill_, _fit_, _center_, or _tile_.
-	Default is _stretch_. Use the additional mode _solid\_color_ to display
-	only the background color, even if a background image is specified.
+	Scaling mode for images: _stretch_, _fill_, _fit_, _center_, _tile_, _span_ or _solid_color_.
+
+	The scaling modes are as follows:
+	- _stretch_ (default): Stretches the image to fit the entire screen.
+	- _fill_: Scales the image while maintaining its aspect ratio to fill the entire screen.
+	- _fit_: Scales the image while maintaining its aspect ratio to fit within the screen without cropping.
+	- _center_: Centers the image on the screen without scaling.
+	- _tile_: Repeats the image across the screen.
+	- _span_: Same as stretch but preserves aspect ratio by adding padding around the image.
+	- _solid_color_: Displays only the background color, ignoring any specified image.
 
 *-o, --output* <name>
 	Select an output to configure. Subsequent appearance options will only


### PR DESCRIPTION
I added a new 'span' option in order to span a picture across all visible monitors.

The picture will be scaled to fit all monitors. Tested with 2 and 3 side by side monitors of different physical size and resolution.

It calculates a scale and image extract for each monitor.